### PR TITLE
Add CVSS and normalized score to the plain report

### DIFF
--- a/output/templates/plain.tpl
+++ b/output/templates/plain.tpl
@@ -4,7 +4,7 @@ No CVEs found.
 {{- define "found" -}}
 {{with $r := .}}{{range $id, $v := .PackageVulnerabilities}}{{range $d := $v -}}
 {{with index $r.Packages $id}}{{.Name}}	{{.Version}}{{end}}
-	{{- with index $r.Vulnerabilities $d}}	{{.Name}}
+	{{- with index $r.Vulnerabilities $d}}	{{.Name}}	{{.Severity}} / {{.NormalizedSeverity}}
 	{{- with .FixedInVersion}}	(fixed: {{.}}){{end}}{{end}}
 {{end}}{{end}}{{end}}{{end}}
 {{- /* The following is the actual bit of the template that runs per item. */ -}}


### PR DESCRIPTION
Looks like this:

```
python3-libs                           3.6.8-48.el8_7.1      CVE-2024-6232    CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H / Medium (fixed: 0:3.6.8-67.el8_10)
python3-libs                           3.6.8-48.el8_7.1      CVE-2023-6597    CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:N / High   (fixed: 0:3.6.8-62.el8_10)
python3-libs                           3.6.8-48.el8_7.1      CVE-2025-4435    CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N / Medium (fixed: 0:3.6.8-70.el8_10)
python3-libs                           3.6.8-48.el8_7.1      CVE-2025-0938    CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:N/I:H/A:N / Medium
python3-libs                           3.6.8-48.el8_7.1      CVE-2025-4516    CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H / Medium
python3-libs                           3.6.8-48.el8_7.1      CVE-2024-0397    CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:L/I:L/A:L / Low
python3-libs                           3.6.8-48.el8_7.1      CVE-2024-7592    CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:U/C:N/I:N/A:H / Low
python3-libs                           3.6.8-48.el8_7.1      CVE-2019-9674    CVSS:3.1/AV:L/AC:L/PR:H/UI:R/S:U/C:N/I:N/A:H / Low
python3-libs                           3.6.8-48.el8_7.1      CVE-2025-8291    CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N / Medium

```