### PR TITLE
Handle unused error from RowsAffected in RecordUpdaterSetStatus

### DIFF
--- a/datastore/sqlite/updater.go
+++ b/datastore/sqlite/updater.go
@@ -124,10 +124,17 @@ func (ms *sqliteMatcherStore) RecordUpdaterSetStatus(ctx context.Context, update
 	}
 
 	ra, err := tag.RowsAffected()
-	zlog.Debug(ctx).
-		Str("factory", updaterSet).
-		Int64("rowsAffected", ra).
-		Msg("status updated for factory updaters")
+	if err != nil {
+		zlog.Warn(ctx).
+			Err(err).
+			Str("factory", updaterSet).
+			Msg("could not determine rows affected for factory updaters status update")
+	} else {
+		zlog.Debug(ctx).
+			Str("factory", updaterSet).
+			Int64("rowsAffected", ra).
+			Msg("status updated for factory updaters")
+	}
 
 	return nil
 }


### PR DESCRIPTION
The error returned by tag.RowsAffected() was silently ignored. Log it as a warning when it occurs, since the transaction has already been committed and the operation itself succeeded.

While this error will most likely not happen we should handle it just in case.

Claude Opus 4.6 was used in part of creating this issue.

Fixes finding from CodeQL quality.