### PR TITLE
fixes related to scanning of mounted file systems

### DIFF
--- a/image/filesystem.go
+++ b/image/filesystem.go
@@ -3,12 +3,18 @@ package image
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/quay/claircore"
 )
 
 func ManifestFromFilesystem(ctx context.Context, rootDir string) (*claircore.Manifest, error) {
+	absDir, err := filepath.Abs(rootDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolving root path: %w", err)
+	}
+
 	digest, err := claircore.ParseDigest(fmt.Sprintf("sha256:%s", strings.Repeat("0", 64)))
 	if err != nil {
 		return nil, err
@@ -16,7 +22,7 @@ func ManifestFromFilesystem(ctx context.Context, rootDir string) (*claircore.Man
 
 	desc := &claircore.LayerDescription{
 		Digest:    fmt.Sprintf("sha256:%s", strings.Repeat("1", 64)),
-		URI:       "file://" + rootDir,
+		URI:       "file://" + absDir,
 		MediaType: "application/vnd.claircore.filesystem",
 	}
 

--- a/image/filesystem.go
+++ b/image/filesystem.go
@@ -25,8 +25,6 @@ func ManifestFromFilesystem(ctx context.Context, rootDir string) (*claircore.Man
 	if err != nil {
 		return nil, err
 	}
-	l.Close()
-
 	return &claircore.Manifest{
 		Hash:   digest,
 		Layers: []*claircore.Layer{l},

--- a/image/filesystem_test.go
+++ b/image/filesystem_test.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"context"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -33,5 +34,56 @@ func TestManifestFromFilesystem_layerNotPreClosed(t *testing.T) {
 	}()
 	if err := l.Close(); err != nil {
 		t.Fatalf("Close returned error: %v", err)
+	}
+}
+
+func TestManifestFromFilesystem_relativePathResolvesCorrectly(t *testing.T) {
+	tmp := t.TempDir()
+	markerDir := filepath.Join(tmp, "var", "lib", "rpm")
+	if err := os.MkdirAll(markerDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(markerDir, "rpmdb.sqlite")
+	if err := os.WriteFile(marker, []byte("fake"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Use a relative path to trigger the bug
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	parent := filepath.Dir(tmp)
+	if err := os.Chdir(parent); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	relPath := filepath.Base(tmp)
+	mf, err := ManifestFromFilesystem(context.Background(), relPath)
+	if err != nil {
+		t.Fatalf("ManifestFromFilesystem: %v", err)
+	}
+
+	l := mf.Layers[0]
+	defer l.Close()
+
+	sys, err := l.FS()
+	if err != nil {
+		t.Fatalf("FS: %v", err)
+	}
+
+	found := false
+	fs.WalkDir(sys, ".", func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if filepath.Base(p) == "rpmdb.sqlite" {
+			found = true
+		}
+		return nil
+	})
+	if !found {
+		t.Fatal("layer FS did not find var/lib/rpm/rpmdb.sqlite — relative path was not resolved correctly")
 	}
 }

--- a/image/filesystem_test.go
+++ b/image/filesystem_test.go
@@ -74,7 +74,7 @@ func TestManifestFromFilesystem_relativePathResolvesCorrectly(t *testing.T) {
 	}
 
 	found := false
-	fs.WalkDir(sys, ".", func(p string, d fs.DirEntry, err error) error {
+	if err := fs.WalkDir(sys, ".", func(p string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return nil
 		}
@@ -82,7 +82,9 @@ func TestManifestFromFilesystem_relativePathResolvesCorrectly(t *testing.T) {
 			found = true
 		}
 		return nil
-	})
+	}); err != nil {
+		t.Fatalf("WalkDir: %v", err)
+	}
 	if !found {
 		t.Fatal("layer FS did not find var/lib/rpm/rpmdb.sqlite — relative path was not resolved correctly")
 	}

--- a/image/filesystem_test.go
+++ b/image/filesystem_test.go
@@ -1,0 +1,37 @@
+package image
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestManifestFromFilesystem_layerNotPreClosed(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmp, "etc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "etc", "os-release"), []byte("ID=test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mf, err := ManifestFromFilesystem(context.Background(), tmp)
+	if err != nil {
+		t.Fatalf("ManifestFromFilesystem: %v", err)
+	}
+	if len(mf.Layers) == 0 {
+		t.Fatal("expected at least one layer")
+	}
+
+	l := mf.Layers[0]
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Close panicked (layer was already closed): %v", r)
+		}
+	}()
+	if err := l.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+}


### PR DESCRIPTION
See commit messages for more details.
But basically, there wer two issues which prevented us from performing a scan on a mounted partition, for example a qcow image.
To test it, update a database and then find some kind of a qcow image of your favorite distro.
Then:
```
guestmount  -a path_to_image.qcow2 -i --ro ./mnt/
```

Then scan the root filesystem mounted at /mnt.